### PR TITLE
The classifier adds to the end of the artifact's name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@
 								<artifact>
 									<file>tile.xml</file>
 									<type>xml</type>
-									<classifier>tile-pom</classifier>
 								</artifact>
 							</artifacts>
 						</configuration>


### PR DESCRIPTION
This addresses rvowles/groovydoc-maven-plugin#9

tile.xml gets pushed to the nexus as `groovydoc-maven-plugin-1.3.tile-pom.xml`, it should be `groovydoc-maven-plugin-1.3.xml`